### PR TITLE
Replaced Split for Preg_Split

### DIFF
--- a/ordinario/http_client.php
+++ b/ordinario/http_client.php
@@ -354,7 +354,7 @@
         $str = fgets($this->socket, 1024);
         $finished = ($str == $lastLine);
         if (!$finished) {
-          list($hdr, $value) = split(': ', $str, 2);
+          list($hdr, $value) = preg_split('/: /', $str, 2);
 // nasty workaround broken multiple same headers (eg. Set-Cookie headers) @FIXME 
           if (isset($headers[$hdr])) {
             $headers[$hdr] .= '; ' . trim($value);


### PR DESCRIPTION
replaced split() for preg_split(). split() has been deprecated as of PHP 5.3
